### PR TITLE
Prevent `msgspec.field` from being called with too many arguments in …

### DIFF
--- a/litestar/dto/factory/_backends/msgspec/utils.py
+++ b/litestar/dto/factory/_backends/msgspec/utils.py
@@ -20,17 +20,13 @@ T = TypeVar("T")
 
 
 def _create_msgspec_field(field_definition: FieldDefinition) -> MsgspecField | None:
-    kws: dict[str, Any] = {}
     if field_definition.default is not Empty:
-        kws["default"] = field_definition.default
+        return field(default=field_definition.default)
 
     if field_definition.default_factory is not None:
-        kws["default_factory"] = field_definition.default_factory
+        return field(default_factory=field_definition.default_factory)
 
-    if not kws:
-        return None
-
-    return field(**kws)  # type:ignore[no-any-return]
+    return None
 
 
 def _create_struct_field_def(


### PR DESCRIPTION
…`_create_struct_for_field_definitions`

`field` throws an error if you pass it both `default` and `default_factory` as kwargs, which was the root cause of `https://github.com/litestar-org/litestar/issues/1685`.

We can fix this by preventing `field` from ever being called with both arguments.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
